### PR TITLE
Fix missing previews for completed image tasks

### DIFF
--- a/web/src/app/(user)/image/page.tsx
+++ b/web/src/app/(user)/image/page.tsx
@@ -2379,6 +2379,21 @@ function isFailedImageTask(task: CanvasImageTask) {
     return ["failed", "fail", "error", "cancelled", "canceled"].includes((task.status || "").toLowerCase());
 }
 
+function imageFromCompletedTask(task: CanvasImageTask, durationMs: number): GeneratedImage | null {
+    const url = task.image_url || task.url || "";
+    if (!url) return null;
+    return {
+        id: task.id,
+        dataUrl: url,
+        storageKey: task.storageKey,
+        durationMs,
+        width: task.width || 0,
+        height: task.height || 0,
+        bytes: task.bytes || 0,
+        mimeType: task.mimeType || "image/png",
+    };
+}
+
 function mergeBackendImageTasks(logs: GenerationLog[], tasks: CanvasImageTask[], config: AiConfig) {
     const nextLogs = [...logs];
     const byKey = new Map<string, GenerationLog>();
@@ -2429,12 +2444,11 @@ function imageLogFromTask(log: GenerationLog, task: CanvasImageTask): Generation
         return { ...log, task, status: "失败", durationMs, failCount: 1, errors: [message], errorDetails: [task.error_detail || message], lastPolledAt: Date.now() };
     }
     if (isCompletedImageTask(task)) {
-        const url = task.image_url || task.url || "";
-        if (!url) {
+        const image = imageFromCompletedTask(task, durationMs);
+        if (!image) {
             return { ...log, task, status: "失败", durationMs, failCount: 1, errors: ["图片生成完成但没有返回图片地址"], errorDetails: [JSON.stringify(task, null, 2)], lastPolledAt: Date.now() };
         }
-        const image: GeneratedImage = { id: task.id, dataUrl: url, storageKey: task.storageKey, durationMs, width: task.width || 0, height: task.height || 0, bytes: task.bytes || 0, mimeType: task.mimeType || "image/png" };
-        return { ...log, task, status: "成功", durationMs, successCount: 1, failCount: 0, imageCount: 1, images: [image], thumbnails: [url], errors: [], errorDetails: [], lastPolledAt: Date.now() };
+        return { ...log, task, status: "成功", durationMs, successCount: 1, failCount: 0, imageCount: 1, images: [image], thumbnails: [image.dataUrl], errors: [], errorDetails: [], lastPolledAt: Date.now() };
     }
     return { ...log, task, durationMs, lastPolledAt: Date.now() };
 }
@@ -2578,7 +2592,11 @@ async function normalizeLog(log: Partial<GenerationLog>): Promise<GenerationLog>
             return { ...item, dataUrl };
         }),
     );
-    const visibleImages = images.filter((image) => Boolean(image.dataUrl));
+    const task = log.task;
+    const fallbackTaskImage = log.status !== "失败" && !images.some((image) => Boolean(image.dataUrl)) && task && !isFailedImageTask(task) && isCompletedImageTask(task)
+        ? imageFromCompletedTask(task, Number(log.durationMs) || 0)
+        : null;
+    const visibleImages = (fallbackTaskImage ? [...images, fallbackTaskImage] : images).filter((image) => Boolean(image.dataUrl));
     const config = normalizeLogConfig(log);
     return {
         id: log.id || nanoid(),


### PR DESCRIPTION
## What changed

Restore a completed image task's preview when the persisted generation log has no usable `images[].dataUrl`.

When history is normalized, the client now:

- reuses `task.image_url` or `task.url` when the task is completed and the log is not failed;
- preserves the task's `storageKey` and existing image metadata;
- avoids writing the large inline Base64 payload again to `images` or `thumbnails`;
- shares the task-to-image construction with the existing completed-task polling path.

## Why

The image workbench can persist a successful log with `successCount/imageCount = 1` while its inline image URL is intentionally stripped during serialization. Completed tasks are not considered recoverable during the initial sync, so the history card renders “成功 1 张” but has no `firstImage` to display.

The task record still contains the completed image URL, so the preview can be restored without regenerating the image.

## Validation

- `bun install --frozen-lockfile`
- `bun run build` ✅
- `git diff --check` ✅
- No new dependencies or API changes.

The file's existing Prettier check reports pre-existing formatting drift in this large source file; this patch is intentionally limited to the recovery path.
