### PR TITLE
修复画布从图片节点链式生成图片时，参考图文件名混入节点标题导致生图渠道返回的图片 URL 损坏的问题

### DIFF
--- a/web/src/app/(user)/canvas/[id]/canvas-client-page.tsx
+++ b/web/src/app/(user)/canvas/[id]/canvas-client-page.tsx
@@ -2182,7 +2182,7 @@ function InfiniteCanvasPage({ projectId }: { projectId: string }) {
             const prompt = `参考图中蓝色高亮覆盖区域是需要修改的位置，蓝色只是编辑标记，不要保留在最终图像中。只修改蓝色高亮区域，其他区域的构图、人物、文字、光影和风格保持不变。修改要求：${userPrompt}`;
             const childId = nanoid();
             const clientTaskId = `client_image_task_${childId}`;
-            const markedReference = { id: `${node.id}-marked`, name: `${node.title || node.id}-marked.png`, type: "image/png", dataUrl: payload.markedDataUrl };
+            const markedReference = { id: `${node.id}-marked`, name: `image-${node.id}-marked.png`, type: "image/png", dataUrl: payload.markedDataUrl };
             const generationMetadata = buildImageGenerationMetadata("edit", generationConfig, 1, [markedReference]);
             const childNode: CanvasNodeData = {
                 id: childId,
@@ -2258,7 +2258,7 @@ function InfiniteCanvasPage({ projectId }: { projectId: string }) {
             const imageConfig = NODE_DEFAULT_SIZE[CanvasNodeType.Image];
             const title = buildAngleLabel(params);
             const prompt = buildAnglePrompt(params);
-            const referenceImages = [{ id: node.id, name: `${node.title || node.id}.png`, type: node.metadata.mimeType || "image/png", dataUrl: node.metadata.content, storageKey: node.metadata.storageKey }];
+            const referenceImages = [{ id: node.id, name: `image-${node.id}.png`, type: node.metadata.mimeType || "image/png", dataUrl: node.metadata.content, storageKey: node.metadata.storageKey }];
             const generationMetadata = buildImageGenerationMetadata("edit", generationConfig, 1, referenceImages);
             const clientTaskId = `client_image_task_${childId}`;
             const startedAt = Date.now();
@@ -2503,7 +2503,7 @@ function InfiniteCanvasPage({ projectId }: { projectId: string }) {
                 if (mode === "image" && isPanoramaNodeType(sourceNode?.type)) {
                     const panoramaSourcePrompt = prompt.trim();
                     const sourceReference: ReferenceImage[] = sourceNode?.metadata?.content
-                        ? [{ id: sourceNode.id, name: (sourceNode.title || sourceNode.id) + ".png", type: sourceNode.metadata.mimeType || "image/png", dataUrl: sourceNode.metadata.content, storageKey: sourceNode.metadata.storageKey }]
+                        ? [{ id: sourceNode.id, name: `image-${sourceNode.id}.png`, type: sourceNode.metadata.mimeType || "image/png", dataUrl: sourceNode.metadata.content, storageKey: sourceNode.metadata.storageKey }]
                         : [];
                     const referenceImages = [...sourceReference, ...generationContext.referenceImages];
                     const panoramaPrompt = buildPanoramaPrompt(effectivePrompt, referenceImages.length > 0);
@@ -2651,7 +2651,7 @@ function InfiniteCanvasPage({ projectId }: { projectId: string }) {
                     const isEmptyImageNode = isImageNode && !sourceNode?.metadata?.content;
                     const sourceReference =
                         isImageNode && sourceNode?.metadata?.content
-                            ? [{ id: sourceNode.id, name: `${sourceNode.title || sourceNode.id}.png`, type: sourceNode.metadata.mimeType || "image/png", dataUrl: sourceNode.metadata.content, storageKey: sourceNode.metadata.storageKey }]
+                            ? [{ id: sourceNode.id, name: `image-${sourceNode.id}.png`, type: sourceNode.metadata.mimeType || "image/png", dataUrl: sourceNode.metadata.content, storageKey: sourceNode.metadata.storageKey }]
                             : [];
                     const referenceImages = sourceReference.length ? sourceReference : generationContext.referenceImages;
                     const generationType = referenceImages.length ? ("edit" as const) : ("generation" as const);
@@ -4827,7 +4827,7 @@ function sourceNodeReferenceImages(node: CanvasNodeData | null) {
     return [
         {
             id: node.id,
-            name: `${node.title || node.id}.png`,
+            name: `image-${node.id}.png`,
             type: node.metadata.mimeType || "image/png",
             dataUrl: node.metadata.content,
             storageKey: node.metadata.storageKey,

--- a/web/src/app/(user)/canvas/components/canvas-node-generation.ts
+++ b/web/src/app/(user)/canvas/components/canvas-node-generation.ts
@@ -243,7 +243,7 @@ function readReferenceImage(node: CanvasNodeData): ReferenceImage | null {
     if (!isCanvasImageNodeType(node.type) || !node.metadata?.content) return null;
     return {
         id: node.id,
-        name: `${node.title || node.id}.png`,
+        name: `image-${node.id}.png`,
         type: node.metadata.mimeType || "image/png",
         dataUrl: node.metadata.content,
         storageKey: node.metadata.storageKey,
@@ -262,7 +262,7 @@ function readReferenceVideo(node: CanvasNodeData): ReferenceVideo | null {
     if (node.type !== CanvasNodeType.Video || !node.metadata?.content) return null;
     return {
         id: node.id,
-        name: `${node.title || node.id}.mp4`,
+        name: `video-${node.id}.mp4`,
         type: node.metadata.mimeType || "video/mp4",
         url: node.metadata.content,
         storageKey: node.metadata.storageKey,
@@ -277,7 +277,7 @@ function readReferenceAudio(node: CanvasNodeData): ReferenceAudio | null {
     if (node.type !== CanvasNodeType.Audio || !node.metadata?.content) return null;
     return {
         id: node.id,
-        name: `${node.title || node.id}.mp3`,
+        name: `audio-${node.id}.mp3`,
         type: node.metadata.mimeType || "audio/mpeg",
         url: node.metadata.content,
         storageKey: node.metadata.storageKey,


### PR DESCRIPTION
<img width="1894" height="706" alt="image" src="https://github.com/user-attachments/assets/09386069-18ca-49e4-a5ce-2bdf269b8f05" />
