### PR TITLE
feat(canvas): 图生图等场景新节点继承源节点生成参数

### DIFF
--- a/web/src/app/(user)/canvas/[id]/canvas-client-page.tsx
+++ b/web/src/app/(user)/canvas/[id]/canvas-client-page.tsx
@@ -145,6 +145,24 @@ function createCanvasNode(type: CanvasNodeType, position: Position, metadata?: C
     };
 }
 
+const INHERITED_GENERATION_KEYS: Partial<Record<CanvasNodeType, ReadonlyArray<keyof CanvasNodeMetadata>>> = {
+    [CanvasNodeType.Image]: ["model", "channelId", "size", "quality", "count"],
+    [CanvasNodeType.Panorama]: ["model", "channelId", "size", "quality", "count"],
+    [CanvasNodeType.Video]: ["model", "channelId", "seconds", "vquality", "mode", "negativePrompt"],
+    [CanvasNodeType.Audio]: ["model", "channelId", "audioVoice", "audioFormat", "audioSpeed", "audioInstructions"],
+};
+
+function inheritedGenerationMetadata(type: CanvasNodeType, sourceNode: CanvasNodeData | undefined): CanvasNodeMetadata | undefined {
+    const keys = INHERITED_GENERATION_KEYS[type];
+    if (!keys || !sourceNode?.metadata) return undefined;
+    const inherited: CanvasNodeMetadata = {};
+    keys.forEach((key) => {
+        const value = sourceNode.metadata?.[key];
+        if (value !== undefined && value !== null && value !== "") inherited[key] = value;
+    });
+    return Object.keys(inherited).length ? inherited : undefined;
+}
+
 export default function CanvasPage() {
     const params = useParams<{ id: string }>();
     const [mounted, setMounted] = useState(false);
@@ -722,7 +740,8 @@ function InfiniteCanvasPage({ projectId }: { projectId: string }) {
 
     const createConnectedNode = useCallback(
         (type: CanvasNodeType, pending: PendingConnectionCreate) => {
-            const metadata = type === CanvasNodeType.Config ? { model: effectiveConfig.imageModel || effectiveConfig.model, size: effectiveConfig.size, count: getGenerationCount(effectiveConfig.canvasImageCount || effectiveConfig.count) } : undefined;
+            const sourceNode = nodesRef.current.find((node) => node.id === pending.connection.nodeId);
+            const metadata = type === CanvasNodeType.Config ? { model: effectiveConfig.imageModel || effectiveConfig.model, size: effectiveConfig.size, count: getGenerationCount(effectiveConfig.canvasImageCount || effectiveConfig.count) } : inheritedGenerationMetadata(type, sourceNode);
             const newNode = createCanvasNode(type, pending.position, metadata);
             const connection = normalizeConnection(pending.connection.nodeId, newNode.id, [...nodesRef.current, newNode], pending.connection.handleType);
             if (!connection) {


### PR DESCRIPTION
## 为什么做这个改动(要解决的问题)

在画布中,**从已有图片节点拉出连线创建新节点(图生图)** 是最常见的迭代路径:用户先调好模型、尺寸、数量生成一张图,不满意后从这张图拉线再生成一张变体。

但改动前,**新建的图片/视频/音频节点不继承源节点的任何生成参数**——所有参数都回退到全局默认配置。用户每次图生图都要重新选择模型、比例尺寸、数量,即使只是想在上一张图的基础上微调。节点连线本来表达了"引用上游生成"的意图,参数却不会跟着走,体验割裂、重复操作多。

## 改动方案

在 `createConnectedNode`(拉线创建新节点的入口)中,从源节点(`pending.connection.nodeId`)读取其已设置的生成参数,写入新节点 metadata:

| 新节点类型 | 继承的参数 |
|---|---|
| 图片 / 全景图 | 模型、渠道、尺寸、质量、数量 |
| 视频 | 模型、渠道、时长、质量、模式、负面提示词 |
| 音频 | 模型、渠道、音色、格式、语速、指令 |

生成时参数优先级是 `节点 metadata → 全局配置 → 默认值`,所以继承的参数直接生效,且打开设置面板可见、可改。

## 设计取舍

- **只复制源节点已设置的参数**:源节点没设置过的字段保持回退全局配置,不改变已有默认行为,旧画布数据无需迁移
- **Config 节点行为不变**:配置节点的职责本就是承载参数再分发给下游,仍取全局配置
- **文本/导演台/组节点不继承**:这些节点没有对应的生成参数体系

## 改动范围

- `web/src/app/(user)/canvas/[id]/canvas-client-page.tsx`(+20 / -1),单文件纯前端改动