### PR TITLE
fix(image): 生图历史记录刷新后图片丢失

### DIFF
--- a/web/src/app/(user)/image/page.tsx
+++ b/web/src/app/(user)/image/page.tsx
@@ -487,9 +487,16 @@ export default function ImagePage() {
                     throw new Error("接口没有返回图片");
                 }
 
+                // 将生成结果持久化到本地存储，刷新后历史记录仍可恢复（base64 不会直接写入日志）
+                const stored = await uploadImage(image.dataUrl);
                 const durableImage = {
                     ...image,
-                    storageKey: "",
+                    dataUrl: stored.url,
+                    storageKey: stored.storageKey,
+                    width: stored.width || image.width,
+                    height: stored.height || image.height,
+                    bytes: stored.bytes || image.bytes,
+                    mimeType: stored.mimeType || image.mimeType,
                 };
                 
                 // 更新结果状态
@@ -738,6 +745,7 @@ export default function ImagePage() {
     };
 
     const saveLog = async (log: GenerationLog) => {
+        const persistedLog = await persistLogImages(log);
         const prevChain = saveLogChainRef.current;
         const nextChain = (async () => {
             try {
@@ -748,14 +756,31 @@ export default function ImagePage() {
             const storedLogs = await readStoredLogs();
             const keys = new Set(imageLogIdentityKeys(log));
             const duplicateLogs = storedLogs.filter((item) => item.id !== log.id && imageLogIdentityKeys(item).some((key) => keys.has(key)));
-            const nextLogs = dedupeGenerationLogs([log, ...storedLogs.filter((item) => item.id !== log.id)]);
+            const nextLogs = dedupeGenerationLogs([persistedLog, ...storedLogs.filter((item) => item.id !== log.id)]);
             setLogs(nextLogs);
             await Promise.all(duplicateLogs.map((item) => logStore.removeItem(item.id)));
-            await logStore.setItem(log.id, serializeLog(log));
+            await logStore.setItem(log.id, serializeLog(persistedLog));
             await persistImageHistory(nextLogs, categories);
         })();
         saveLogChainRef.current = nextChain;
         await nextChain;
+    };
+
+    const persistLogImages = async (log: GenerationLog): Promise<GenerationLog> => {
+        const images = log.images || [];
+        if (!images.some((image) => !image.storageKey && image.dataUrl?.startsWith("data:image/"))) return log;
+        const persistedImages = await Promise.all(
+            images.map(async (image) => {
+                if (image.storageKey || !image.dataUrl?.startsWith("data:image/")) return image;
+                try {
+                    const stored = await uploadImage(image.dataUrl);
+                    return { ...image, dataUrl: stored.url, storageKey: stored.storageKey, width: stored.width || image.width, height: stored.height || image.height, bytes: stored.bytes || image.bytes, mimeType: stored.mimeType || image.mimeType };
+                } catch {
+                    return image;
+                }
+            }),
+        );
+        return { ...log, images: persistedImages };
     };
 
     const refreshLogs = async () => {


### PR DESCRIPTION
## 问题

生图工作台生成图片后,刷新页面,历史记录中的图片消失,显示"没有可显示的图片"。

## 根因

生成结果入库(写入 localforage)前,图片没有持久化到本地存储:

1. 序列化时 `persistableImageUrl` 对 **base64(`data:image/...`)且无 `storageKey`** 的图片直接返回空字符串——base64 被清空
2. 前端直连路径生成成功后 `storageKey` 被**强制置空**(`{ ...image, storageKey: "" }`)
3. 后端任务路径(`imageLogFromTask`)回填的 `task.storageKey` 也为空(服务端 `task.StorageKey = ""`)

刷新后 `resolveImageUrl(storageKey, dataUrl)` 两个都是空 → 图片无法恢复。

影响所有返回 **base64 图片**的渠道:ComfyUI、OpenAI 兼容 `b64_json`、Responses API、智谱、Agnes 等;返回 http URL 的渠道不受影响。

## 修复

`web/src/app/(user)/image/page.tsx`(+28 / -3):

1. **前端直连路径**:生成成功后先 `uploadImage()` 持久化到本地存储,拿到 `storageKey` 再写入日志
2. **统一兜底 `persistLogImages`**(在 `saveLog` 入口):无论哪条路径(直连、后端任务轮询、工作流),凡是"base64 且无 storageKey"的图片,保存前先持久化——覆盖登录后走后端任务路径的场景

修复后图片入库前先落盘 IndexedDB,刷新时通过 `resolveImageUrl(storageKey)` 恢复。

## 备注

- 修复前已丢失的历史记录无法恢复(数据已清空),新生成的图片正常
- 画布节点生成路径不受影响(已有 storageKey 上传逻辑)