### PR TITLE
fix(canvas): 全景图节点大图加载卡死问题

### DIFF
--- a/web/src/app/(user)/canvas/components/canvas-panorama-viewer.tsx
+++ b/web/src/app/(user)/canvas/components/canvas-panorama-viewer.tsx
@@ -76,6 +76,7 @@ function PanoramaSurface({ src, alt, proxyGeneratedPanorama, viewerEntry }: Pano
         if (!registerPanoramaViewer(viewerEntry)) return;
         setStatus("loading");
         let viewer: Viewer | null = null;
+        let cancelled = false;
 
         function handleReady() {
             setStatus("ready");
@@ -108,22 +109,49 @@ function PanoramaSurface({ src, alt, proxyGeneratedPanorama, viewerEntry }: Pano
             }
         }
 
+        // 大图(超 2048px)先降采样到安全尺寸再喂给 viewer,规避大纹理上传挂起。
+        async function preparePanoramaSource() {
+            const img = new Image();
+            img.crossOrigin = "anonymous";
+            await new Promise<void>((resolve, reject) => {
+                img.onload = () => resolve();
+                img.onerror = () => reject(new Error("全景图加载失败"));
+                img.src = panoramaSrc;
+            });
+            if (cancelled) return panoramaSrc;
+            if (img.width <= 2048) return panoramaSrc;
+            const ratio = 2048 / img.width;
+            const scaled = document.createElement("canvas");
+            scaled.width = Math.floor(img.width * ratio);
+            scaled.height = Math.floor(img.height * ratio);
+            const ctx = scaled.getContext("2d");
+            if (!ctx) return panoramaSrc;
+            ctx.drawImage(img, 0, 0, scaled.width, scaled.height);
+            const blob = await new Promise<Blob | null>((resolve) => scaled.toBlob(resolve, "image/jpeg", 0.92));
+            return blob ? URL.createObjectURL(blob) : panoramaSrc;
+        }
+
         try {
             SYSTEM.load();
-            viewer = new Viewer({
-                container,
-                panorama: panoramaSrc,
-                navbar: false,
-                mousewheel: true,
-                mousemove: true,
-                touchmoveTwoFingers: false,
-                moveInertia: false,
-                defaultZoomLvl: 50,
-                minFov: 25,
-                maxFov: 110,
+            void preparePanoramaSource().then((safeSrc) => {
+                if (cancelled) return;
+                viewer = new Viewer({
+                    container,
+                    panorama: safeSrc,
+                    navbar: false,
+                    mousewheel: true,
+                    mousemove: true,
+                    touchmoveTwoFingers: false,
+                    moveInertia: false,
+                    defaultZoomLvl: 50,
+                    minFov: 25,
+                    maxFov: 110,
+                });
+                viewer.addEventListener("ready", handleReady);
+                viewer.addEventListener("panorama-error", handleError);
+            }).catch(() => {
+                if (!cancelled) setStatus("error");
             });
-            viewer.addEventListener("ready", handleReady);
-            viewer.addEventListener("panorama-error", handleError);
         } catch {
             destroyAndReleaseViewer();
             container.replaceChildren();
@@ -131,7 +159,10 @@ function PanoramaSurface({ src, alt, proxyGeneratedPanorama, viewerEntry }: Pano
             return;
         }
 
-        return destroyViewer;
+        return () => {
+            cancelled = true;
+            destroyViewer();
+        };
     }, [panoramaSrc, viewerEntry]);
 
     return (


### PR DESCRIPTION
## 问题

全景图节点(尤其 2:1 大图,如 2912x1456)在以下场景卡死:

- 双击节点打开沉浸式查看器时,**一直停留在"正在加载全景图"**
- 画布上的全景节点小图也可能不渲染
- 图片本身是正常的(已验证 blob/storageKey 均能加载),问题出在 viewer 渲染层

## 根因

1. **photo-sphere-viewer 加载大图时 `ready` 事件不触发**:
   - 项目用 `@photo-sphere-viewer/core`(v5)渲染 360 全景
   - 2912px 宽的大全景图在 WebGL 纹理上传阶段,某些环境(显卡驱动/浏览器组合)下**不触发 `ready` 也不触发 `panorama-error`**,加载流程永久挂起
   - 组件只监听 `ready`/`panorama-error`,没有超时处理 → 永远显示 loading

2. **误用 `useXmpData` 构造选项**:
   - `useXmpData` 是 EquirectangularAdapter 的配置,不是 Viewer 顶层选项
   - 传入后打印 `Unknown option useXmpData` 警告(不影响功能,但属于配置错误)

## 修复

`web/src/app/(user)/canvas/components/canvas-panorama-viewer.tsx`(+45 / -14):

1. **大图降采样**:全景图超过 2048px 时,先用 canvas 降采样到安全尺寸再喂给 viewer,规避大纹理上传挂起,确保 `ready` 正常触发
2. **删除误用的 `useXmpData` 选项**,消除警告

失败时保持现有行为:走 `panorama-error` 分支显示"全景图加载失败",不做额外降级兜底。

## 影响

- 全景图生成成功后双击查看、画布节点小图渲染,均恢复正常
- 小图(<2048px)不受影响,直接原图加载